### PR TITLE
Hotfix #8 Pin vault-ssh-cli to 1.8.1

### DIFF
--- a/base/fcos/ignition/main.tf
+++ b/base/fcos/ignition/main.tf
@@ -18,7 +18,7 @@ data "ct_config" "this" {
     }),
     templatefile("${path.module}/templates/ssh.bu.tftpl", {
       vault_url             = var.vault_url
-      vault_ssh_cli_version = "latest"
+      vault_ssh_cli_version = "1.8.1"
     }),
     templatefile("${path.module}/templates/pki.bu.tftpl", {
       fqdn            = var.fqdn


### PR DESCRIPTION
Since the release of 1.8.2 host key signing is broken. Downgrade from latest to 1.8.1 until further investigation