### PR TITLE
Update dns-record to current cloudflare module

### DIFF
--- a/base/dns-record/README.md
+++ b/base/dns-record/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.4 |
-| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 4.25.0 |
+| <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | >= 4.40.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | >= 4.25.0 |
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 4.40.0 |
 
 ## Modules
 

--- a/base/dns-record/main.tf
+++ b/base/dns-record/main.tf
@@ -2,7 +2,7 @@ resource "cloudflare_record" "this" {
   zone_id = var.zone_id
   name    = var.name
   type    = var.type
-  value   = var.value
+  content = var.value
   proxied = false
   comment = "managed-by:Terraform;"
 }

--- a/base/dns-record/tests/create-record.tftest.hcl
+++ b/base/dns-record/tests/create-record.tftest.hcl
@@ -1,0 +1,38 @@
+run "create-A-record" {
+  variables {
+    zone_id = "96c197469cc8a73db1d9c6f1bba05574"
+    name    = "tftest.testing"
+    type    = "A"
+    value   = "203.0.113.42"
+  }
+}
+
+run "create-AAAA-record" {
+  variables {
+    zone_id = "96c197469cc8a73db1d9c6f1bba05574"
+    name    = "tftest.testing"
+    type    = "AAAA"
+    value   = "2001:db8::acab"
+  }
+}
+
+run "create-CNAME-record" {
+  variables {
+    zone_id = "96c197469cc8a73db1d9c6f1bba05574"
+    name    = "tftest-cname.testing"
+    type    = "CNAME"
+    value   = "tftest.testing.nop.systems"
+  }
+}
+
+run "create-A-record-null" {
+  variables {
+    zone_id = "96c197469cc8a73db1d9c6f1bba05574"
+    name    = "tftest-null.testing"
+    type    = "A"
+    value   = null
+  }
+  expect_failures = [
+    var.value
+  ]
+}

--- a/base/dns-record/variables.tf
+++ b/base/dns-record/variables.tf
@@ -16,4 +16,5 @@ variable "type" {
 variable "value" {
   description = "record value (e.g. IP address)"
   type        = string
+  nullable    = false
 }

--- a/base/dns-record/versions.tf
+++ b/base/dns-record/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 4.25.0"
+      version = ">= 4.40.0"
     }
   }
 }


### PR DESCRIPTION
the value attribute has been deprecated and replaced by content. Due to the new validation a input of null causes problems, therefore added `nullable=false` for easier debugging