### PR TITLE
Bump versions and move images from butane to terraform

### DIFF
--- a/services/monitoring/README.md
+++ b/services/monitoring/README.md
@@ -15,10 +15,10 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cname_records"></a> [cname\_records](#module\_cname\_records) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.1.0 |
-| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.5.3 |
-| <a name="module_internal_records"></a> [internal\_records](#module\_internal\_records) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.1.0 |
-| <a name="module_service_record"></a> [service\_record](#module\_service\_record) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.1.0 |
+| <a name="module_cname_records"></a> [cname\_records](#module\_cname\_records) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
+| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.0 |
+| <a name="module_internal_records"></a> [internal\_records](#module\_internal\_records) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
+| <a name="module_service_record"></a> [service\_record](#module\_service\_record) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
 
 ## Resources
 

--- a/services/monitoring/caddy.bu
+++ b/services/monitoring/caddy.bu
@@ -172,7 +172,7 @@ storage:
           After=network-online.target local-fs.target vault-agent.service
 
           [Container]
-          Image=docker.io/library/caddy:${caddy_version}
+          Image=${caddy_image}
           Pull=newer
           AutoUpdate=registry
           LogDriver=journald

--- a/services/monitoring/grafana.bu
+++ b/services/monitoring/grafana.bu
@@ -95,7 +95,7 @@ storage:
           After=network-online.target local-fs.target vault-agent.service
 
           [Container]
-          Image=docker.io/grafana/grafana-oss:${grafana_version}
+          Image=${grafana_image}
           Pull=newer
           LogDriver=journald
           UserNS=auto
@@ -138,7 +138,7 @@ storage:
           After=network-online.target local-fs.target vault-agent.service
 
           [Container]
-          Image=docker.io/grafana/grafana-image-renderer:${grafana_image_renderer_version}
+          Image=${grafana_image_renderer_image}
           Pull=newer
           AutoUpdate=registry
           LogDriver=journald

--- a/services/monitoring/loki.bu
+++ b/services/monitoring/loki.bu
@@ -174,6 +174,16 @@ storage:
 
           [Install]
           WantedBy=multi-user.target default.target
+    - path: /etc/containers/systemd/loki.image
+      mode: 0644
+      contents:
+        inline: |
+          [Unit]
+          Wants=network-online.target
+          After=network-online.target
+
+          [Image]
+          Image=${loki_image}
     - path: /etc/containers/systemd/loki-write.container
       mode: 0644
       contents:
@@ -183,7 +193,7 @@ storage:
           After=network-online.target local-fs.target minio.service vault-agent.service
 
           [Container]
-          Image=docker.io/grafana/loki:${loki_version}
+          Image=loki.image
           Exec=-config.file=/etc/loki/loki.yaml -config.expand-env=true -target=write
           Pull=newer
           LogDriver=journald
@@ -218,7 +228,7 @@ storage:
           After=network-online.target local-fs.target minio.service vault-agent.service
 
           [Container]
-          Image=docker.io/grafana/loki:${loki_version}
+          Image=loki.image
           Exec=-config.file=/etc/loki/loki.yaml -config.expand-env=true -target=backend -legacy-read-mode=false
           Pull=newer
           LogDriver=journald
@@ -272,7 +282,7 @@ storage:
           After=network-online.target local-fs.target vault-agent.service
 
           [Container]
-          Image=docker.io/minio/minio:${minio_version}
+          Image=${minio_image}
           Exec=server --address 0.0.0.0:9000 --console-address 0.0.0.0:9001 /data
           Pull=newer
           LogDriver=journald

--- a/services/monitoring/prometheus.bu
+++ b/services/monitoring/prometheus.bu
@@ -99,7 +99,7 @@ storage:
           After=network-online.target local-fs.target
 
           [Container]
-          Image=docker.io/prom/prometheus:${prometheus_version}
+          Image=:{prometheus_image}
           Pull=newer
           LogDriver=journald
           UserNS=auto
@@ -155,7 +155,7 @@ storage:
           After=network-online.target local-fs.target vault-agent.service
 
           [Container]
-          Image=ghcr.io/nop-systems/xo-sd-proxy:${xo_sd_proxy_version}
+          Image=${xo_sd_proxy_image}
           Pull=newer
           LogDriver=journald
           UserNS=auto
@@ -223,7 +223,7 @@ storage:
           After=network-online.target local-fs.target
 
           [Container]
-          Image=docker.io/prom/alertmanager:${alertmanager_version}
+          Image=${alertmanager_version}
           Pull=newer
           LogDriver=journald
           UserNS=auto
@@ -253,7 +253,7 @@ storage:
           After=network-online.target local-fs.target
 
           [Container]
-          Image=docker.io/prom/blackbox-exporter:${blackbox_exporter_version}
+          Image=${blackbox_exporter_image}
           Pull=newer
           LogDriver=journald
           UserNS=auto
@@ -278,7 +278,7 @@ storage:
           After=network-online.target local-fs.target
 
           [Container]
-          Image=docker.io/prom/snmp-exporter:${snmp_exporter_version}
+          Image=${snmp_exporter_image}
           Pull=newer
           LogDriver=journald
           UserNS=auto


### PR DESCRIPTION
- move full image path to template variable instead of splitting image repo and version, hopefully this will make some kind of dependabot setup simpler
- bump all image versions
- bump fcos (v0.6.0) and dns (v0.2.0) modules