### PR TITLE
nextcloud monitoring fixes

### DIFF
--- a/services/nextcloud/main.tf
+++ b/services/nextcloud/main.tf
@@ -6,7 +6,8 @@ locals {
       trusted_domains = [
         var.fqdn,
         var.nextcloud_public_fqdn,
-        var.nextcloud_service_fqdn
+        var.nextcloud_service_fqdn,
+        "systemd-nextcloud"
       ]
       trusted_proxies               = ["10.89.0.0/16", "fd00::/8"]
       log_type                      = "syslog"

--- a/services/nextcloud/nextcloud.bu
+++ b/services/nextcloud/nextcloud.bu
@@ -175,7 +175,7 @@ storage:
           After=network-online.target
 
           [Image]
-          Image=ghcr.io/hoellen/nextcloud:${nextcloud_version}
+          Image=${nextcloud_image}
     - path: /etc/containers/systemd/nextcloud.network
       mode: 0644
       contents:
@@ -373,7 +373,7 @@ storage:
           After=network-online.target local-fs.target vault-agent.service
 
           [Container]
-          Image=docker.io/library/postgres:${postgres_version}
+          Image=${postgres_image}
           Pull=newer
           AutoUpdate=registry
           LogDriver=journald
@@ -412,7 +412,7 @@ storage:
           After=network-online.target local-fs.target
 
           [Container]
-          Image=docker.io/valkey/valkey:${valkey_version}
+          Image=${valkey_image}
 
           Pull=newer
           LogDriver=journald

--- a/services/nextcloud/nextcloud.bu
+++ b/services/nextcloud/nextcloud.bu
@@ -443,16 +443,18 @@ storage:
       contents:
         inline: |
           template {
+            destination = "/vault/secrets/postgres/password"
+            perms = "0600"
             contents = <<-EOT
               {{- with secret "kv/data/service/${ nextcloud_service_fqdn }/postgres" -}}
               {{ .Data.data.password }}
               {{- end }}
               EOT
-            perms = "0600"
-            destination = "/vault/secrets/postgres/password"
           }
 
           template {
+            destination = "/vault/secrets/nextcloud/autoconfig.php"
+            perms = "0600"
             contents = <<-EOT
               <?php
                 $AUTOCONFIG = array (
@@ -471,11 +473,11 @@ storage:
                   {{- end }}
                 );
               EOT
-            perms = "0600"
-            destination = "/vault/secrets/nextcloud/autoconfig.php"
           }
 
           template {
+            destination = "/vault/secrets/nextcloud/provision/config.json"
+            perms = "0600"
             contents = <<-EOT
               {{ with secret "kv/data/service/${ nextcloud_service_fqdn }/settings" -}}
               {
@@ -487,18 +489,26 @@ storage:
               }
               {{- end }}
               EOT
-            perms = "0600"
-            destination = "/vault/secrets/nextcloud/provision/config.json"
           }
 
           template {
+            destination = "/vault/secrets/nextcloud/exporter.env"
+            perms = "0600"
             contents = <<-EOT
               {{ with secret "kv/data/service/${ nextcloud_service_fqdn }/settings" -}}
               NEXTCLOUD_AUTH_TOKEN={{ .Data.data.serverinfo_token }}
               {{- end }}
               EOT
+          }
+
+          template {
+            destination = "/vault/secrets/monitoring/extcloud-postgres-datasource"
             perms = "0600"
-            destination = "/vault/secrets/nextcloud/exporter.env"
+            contents = <<-EOT
+              {{- with secret "kv/data/service/${ nextcloud_service_fqdn }/postgres" -}}
+              postgresql://nextcloud:{{ .Data.data.password }}@systemd-postgres:5432/nextcloud?sslmode=disable
+              {{- end }}
+              EOT
           }
     - path: /etc/monitoring/alloy.d/nextcloud.alloy
       contents:
@@ -514,15 +524,27 @@ storage:
             ]
           }
 
+          local.file "nextcloud_postgres_datasource" {
+            filename = "/secrets/nextcloud-postgres-datasource"
+            is_secret = true
+          }
+
+          prometheus.exporter.postgres "nextcloud" {
+            data_source_names = [local.file.nextcloud_postgres_datasource.content]
+          }
+
           prometheus.scrape "postgres" {
-            forward_to = [
-              prometheus.relabel.replace_instance.receiver,
-            ]
-            targets = [
-              {
-                "__address__" = "systemd-postgres-exporter:9187",
-              },
-            ]
+            forward_to = [prometheus.relabel.replace_instance.receiver]
+            targets = prometheus.exporter.postgres.nextcloud.targets
+          }
+
+          prometheus.exporter.redis "nextcloud" {
+              redis_addr = "systemd-valkey:6379"
+          }
+
+          prometheus.scrape "valkey" {
+            forward_to = [prometheus.relabel.replace_instance.receiver]
+            targets = prometheus.exporter.redis.nextcloud.targets
           }
     - path: /etc/containers/systemd/nextcloud-exporter.container
       mode: 0644
@@ -555,39 +577,11 @@ storage:
 
           [Install]
           WantedBy=default.target
-    - path: /etc/containers/systemd/postgres-exporter.container
-      mode: 0644
+    - path: /etc/containers/systemd/monitoring.pod.d/nextcloud.conf
       contents:
         inline: |
-          [Unit]
-          Description=postgres prometheus exporter
-          After=network-online.target local-fs.target vault-agent.service postgres.service
-          Wants=vault-agent.service postgres.service
-
-          [Container]
-          Image=quay.io/prometheuscommunity/postgres-exporter:latest
-          Pull=newer
-          AutoUpdate=registry
-          LogDriver=journald
-          UserNS=auto
-
-          Environment=DATA_SOURCE_USER=nextcloud
-          Environment=DATA_SOURCE_PASS_FILE=/run/secrets/password
-          Environment=DATA_SOURCE_URI=systemd-postgres:5432/nextcloud?sslmode=disable
-
-          Volume=/var/containers/secrets/postgres/password:/run/secrets/password:z,idmap=uids=@0-65534-1,ro
-
-          Network=container.network
+          [Pod]
           Network=nextcloud.network
-
-          [Service]
-          Restart=always
-          RestartSec=1s
-          RestartSteps=10
-          RestartMaxDelaySec=5m
-
-          [Install]
-          WantedBy=default.target
     - path: /usr/local/bin/occ
       mode: 0755
       contents:


### PR DESCRIPTION
- **nextcloud: add systemd-nextcloud to trusted domains so nextcloud-exporter doesn’t get an error**
- **fix: commit forgotten file**
- **nextcloud: remove postgres-exporter and use alloy’s included exporters for redis and postgres**
