### PR TITLE
bumps

### DIFF
--- a/services/authentik/README.md
+++ b/services/authentik/README.md
@@ -15,7 +15,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.4 |
+| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.5 |
 | <a name="module_service_cname_record"></a> [service\_cname\_record](#module\_service\_cname\_record) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
 
 ## Resources

--- a/services/authentik/main.tf
+++ b/services/authentik/main.tf
@@ -1,10 +1,10 @@
 module "fcos" {
-  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.4"
+  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.5"
   # source = "../../base/fcos/stack"
 
   fqdn      = var.fqdn
   desc      = "authentik"
-  xo_tags   = concat(var.xo_tags, ["authentik"])
+  xo_tags   = concat(var.xo_tags, ["service=authentik"])
   memory    = 4096
   cpu_cores = 4
   disk_size = 100
@@ -12,7 +12,7 @@ module "fcos" {
   butane_snippets = [templatefile("${path.module}/authentik.bu", {
     service_fqdn        = var.service_fqdn
     trusted_proxy_cidrs = var.trusted_proxy_cidrs
-    authentik_version   = "2025.2.2"
+    authentik_version   = "2025.2.3"
   })]
 
   cloudflare_zone_id     = var.cloudflare_zone_id

--- a/services/monitoring/README.md
+++ b/services/monitoring/README.md
@@ -16,7 +16,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cname_records"></a> [cname\_records](#module\_cname\_records) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
-| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.0 |
+| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.5 |
 | <a name="module_internal_records"></a> [internal\_records](#module\_internal\_records) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
 | <a name="module_service_record"></a> [service\_record](#module\_service\_record) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
 

--- a/services/monitoring/main.tf
+++ b/services/monitoring/main.tf
@@ -8,7 +8,7 @@ locals {
 }
 
 module "fcos" {
-  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.0"
+  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.5"
 
   fqdn      = var.fqdn
   desc      = "Monitoring Stack"
@@ -21,13 +21,13 @@ module "fcos" {
     templatefile("${path.module}/prometheus.bu", {
       service_fqdn = var.service_fqdn
       # https://quay.io/repository/prometheus/prometheus?tab=tags
-      prometheus_image = "quay.io/prometheus/prometheus:v2.54.1"
+      prometheus_image = "quay.io/prometheus/prometheus:v3.2.1"
       # https://quay.io/repository/prometheus/alertmanager?tab=tags
-      alertmanager_image = "quay.io/prometheus/alertmanager:v0.27.0"
+      alertmanager_image = "quay.io/prometheus/alertmanager:v0.28.1"
       # https://quay.io/repository/prometheus/blackbox-exporter?tab=tags
-      blackbox_exporter_image = "quay.io/prometheus/blackbox-exporter:v0.25.0"
+      blackbox_exporter_image = "quay.io/prometheus/blackbox-exporter:v0.26.0"
       # https://quay.io/repository/prometheus/snmp-exporter?tab=tags
-      snmp_exporter_image = "quay.io/prometheus/snmp-exporter:v0.26.0"
+      snmp_exporter_image = "quay.io/prometheus/snmp-exporter:v0.28.0"
       # https://github.com/nop-systems/xo-sd-proxy/pkgs/container/xo-sd-proxy
       xo_sd_proxy_image = "ghcr.io/nop-systems/xo-sd-proxy:v0.1.0"
     }),
@@ -36,14 +36,14 @@ module "fcos" {
       # https://hub.docker.com/r/grafana/grafana-image-renderer/tags
       grafana_image_renderer_image = "docker.io/grafana/grafana-image-renderer:latest"
       # https://hub.docker.com/r/grafana/grafana-oss/tags
-      grafana_image = "docker.io/grafana/grafana-oss:11.2.0"
+      grafana_image = "docker.io/grafana/grafana-oss:11.6.0"
       service_fqdn  = var.service_fqdn
     }),
     templatefile("${path.module}/loki.bu", {
       # https://github.com/grafana/loki/releases
-      loki_image = "docker.io/grafana/loki:3.1.1"
+      loki_image = "docker.io/grafana/loki:3.4.2"
       # https://hub.docker.com/r/minio/minio/tags
-      minio_image  = "docker.io/minio/minio:RELEASE.2024-08-29T01-40-52Z"
+      minio_image  = "docker.io/minio/minio:RELEASE.2025-03-12T18-04-18Z"
       service_fqdn = var.service_fqdn
     }),
     templatefile("${path.module}/caddy.bu", {
@@ -51,7 +51,7 @@ module "fcos" {
       admin_pki_mount   = var.admin_pki_mount
       alertmanager_fqdn = var.alertmanager_fqdn
       # https://hub.docker.com/_/caddy
-      caddy_image     = "docker.io/library/caddy:2.8"
+      caddy_image     = "docker.io/library/caddy:2.9"
       fqdn            = var.fqdn
       grafana_fqdn    = var.grafana_fqdn
       ingress_fqdn    = var.ingress_fqdn

--- a/services/nextcloud/README.md
+++ b/services/nextcloud/README.md
@@ -16,7 +16,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_collabora_service_cname_record"></a> [collabora\_service\_cname\_record](#module\_collabora\_service\_cname\_record) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
-| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.0 |
+| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.5 |
 | <a name="module_nextcloud_service_cname_record"></a> [nextcloud\_service\_cname\_record](#module\_nextcloud\_service\_cname\_record) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
 
 ## Resources

--- a/services/nextcloud/caddy.bu
+++ b/services/nextcloud/caddy.bu
@@ -96,7 +96,7 @@ storage:
           # prevent systemd-nextcloud from bein proxied to nextcloud as it is configured as trusted domain
           systemd-nextcloud {
             tls internal
-            responde "Forbidden" 403
+            respond "Forbidden" 403
           }
 
           https://${fqdn}, https://${nextcloud_service_fqdn}, https:// {

--- a/services/nextcloud/main.tf
+++ b/services/nextcloud/main.tf
@@ -83,7 +83,7 @@ locals {
 }
 
 module "fcos" {
-  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.0"
+  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.5"
   # source = "../../base/fcos/stack"
 
   fqdn      = var.fqdn
@@ -110,11 +110,11 @@ module "fcos" {
       nextcloud_custom_config = jsonencode(merge({ system = {} }, var.config))
 
       # https://github.com/hoellen/docker-nextcloud/pkgs/container/nextcloud
-      nextcloud_image = "ghcr.io/hoellen/nextcloud:30.0.0"
+      nextcloud_image = "ghcr.io/hoellen/nextcloud:31.0.2"
       # https://hub.docker.com/_/postgres
       postgres_image = "docker.io/library/postgres:16-alpine"
       # https://hub.docker.com/r/valkey/valkey
-      valkey_image = "docker.io/valkey/valkey:7.2.6"
+      valkey_image = "docker.io/valkey/valkey:8.0"
     }),
     templatefile("${path.module}/caddy.bu", {
       fqdn                   = var.fqdn
@@ -123,7 +123,7 @@ module "fcos" {
       nextcloud_service_fqdn = var.nextcloud_service_fqdn
       collabora_service_fqdn = var.collabora_service_fqdn
       # https://hub.docker.com/_/caddy
-      caddy_image = "docker.io/library/caddy:2.8"
+      caddy_image = "docker.io/library/caddy:2.9"
     }),
     templatefile("${path.module}/collabora.bu", {
       fqdn                   = var.fqdn
@@ -132,7 +132,7 @@ module "fcos" {
       nextcloud_public_fqdn  = var.nextcloud_public_fqdn
       nextcloud_service_fqdn = var.nextcloud_service_fqdn
       # https://hub.docker.com/r/collabora/code/tags
-      collabora_code_image = "docker.io/collabora/code:24.04.7.2.1"
+      collabora_code_image = "docker.io/collabora/code:24.04.13.2.1"
       # https://hub.docker.com/r/elestio/languagetool/tags
       languagetool_image = "docker.io/elestio/languagetool:latest"
     }),

--- a/services/openproject/README.md
+++ b/services/openproject/README.md
@@ -30,7 +30,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.4 |
+| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.5 |
 | <a name="module_service_cname_record"></a> [service\_cname\_record](#module\_service\_cname\_record) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
 
 ## Resources

--- a/services/openproject/main.tf
+++ b/services/openproject/main.tf
@@ -1,10 +1,10 @@
 module "fcos" {
-  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.4"
+  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.5"
   # source = "../../base/fcos/stack"
 
   fqdn      = var.fqdn
   desc      = "OpenProject project managing software"
-  xo_tags   = concat(var.xo_tags, ["service:openproject"])
+  xo_tags   = concat(var.xo_tags, ["service=openproject"])
   memory    = 1024 * 4
   cpu_cores = 4
   disk_size = 40
@@ -18,15 +18,15 @@ module "fcos" {
     trusted_proxies  = join(" ", var.trusted_proxies)
     authentik_host   = var.authentik_host
     # https://hub.docker.com/r/openproject/openproject
-    openproject_version = "15.4-slim"
+    openproject_image = "docker.io/openproject/openproject:15.4-slim"
     # https://hub.docker.com/_/caddy
-    caddy_version = "2.9"
+    caddy_image = "docker.io/library/caddy:2.9"
     # https://hub.docker.com/_/postgres
-    postgres_version = "16-alpine"
+    postgres_image = "docker.io/library/postgres:16-alpine"
     # https://hub.docker.com/_/memcached
-    memcached_version = "1.6-alpine"
+    memcached_image = "docker.io/library/memcached:1.6-alpine"
     # https://github.com/goauthentik/authentik/pkgs/container/ldap
-    authentik_version = "2025.2"
+    authentik_ldap_image = "ghcr.io/goauthentik/ldap:2025.2"
   })]
 
   cloudflare_zone_id     = var.cloudflare_zone_id

--- a/services/openproject/openproject.bu
+++ b/services/openproject/openproject.bu
@@ -18,7 +18,7 @@ storage:
           After=network-online.target
 
           [Image]
-          Image=docker.io/openproject/openproject:${openproject_version}
+          Image=${openproject_image}
     - path: /etc/containers/systemd/openproject.pod
       mode: 0644
       contents:
@@ -199,7 +199,7 @@ storage:
           After=network-online.target local-fs.target
 
           [Container]
-          Image=docker.io/library/caddy:${caddy_version}
+          Image=${caddy_image}
           Pull=newer
           AutoUpdate=registry
           LogDriver=journald
@@ -267,7 +267,7 @@ storage:
           After=network-online.target local-fs.target vault-agent.service
 
           [Container]
-          Image=docker.io/library/postgres:${postgres_version}
+          Image=${postgres_image}
           Pull=newer
           AutoUpdate=registry
           LogDriver=journald
@@ -303,7 +303,7 @@ storage:
           After=network-online.target local-fs.target
 
           [Container]
-          Image=docker.io/library/memcached:${memcached_version}
+          Image=${memcached_image}
 
           Pull=newer
           AutoUpdate=registry
@@ -329,7 +329,7 @@ storage:
           After=network-online.target local-fs.target vault-agent.service
 
           [Container]
-          Image=ghcr.io/goauthentik/ldap:${authentik_version}
+          Image=${authentik_ldap_image}
           Pull=newer
           AutoUpdate=registry
           LogDriver=journald

--- a/services/pretix/README.md
+++ b/services/pretix/README.md
@@ -15,7 +15,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_pretix"></a> [pretix](#module\_pretix) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.4 |
+| <a name="module_pretix"></a> [pretix](#module\_pretix) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.5 |
 | <a name="module_service_cname_record"></a> [service\_cname\_record](#module\_service\_cname\_record) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
 
 ## Resources

--- a/services/pretix/main.tf
+++ b/services/pretix/main.tf
@@ -1,10 +1,10 @@
 module "pretix" {
-  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.4"
+  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.5"
   # source = "../../base/fcos/stack"
 
   fqdn      = var.fqdn
-  desc      = "Pretix"
-  xo_tags   = var.xo_tags
+  desc      = "Pretix Ticket Shop"
+  xo_tags   = concat(var.xo_tags, ["service=pretix"])
   memory    = 8192
   cpu_cores = 4
   disk_size = 40

--- a/services/pretix/main.tf
+++ b/services/pretix/main.tf
@@ -21,7 +21,7 @@ module "pretix" {
       timezone            = var.timezone
       currency            = var.currency
       # https://hub.docker.com/r/pretix/standalone
-      pretix_image = "docker.io/pretix/standalone:2025.2"
+      pretix_image = "docker.io/pretix/standalone:2025.3"
       # https://hub.docker.com/_/postgres
       postgres_image = "docker.io/library/postgres:16-alpine"
       # https://hub.docker.com/r/valkey/valkey

--- a/services/xenorchestra/README.md
+++ b/services/xenorchestra/README.md
@@ -15,7 +15,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.4 |
+| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.5 |
 | <a name="module_service_cname_record"></a> [service\_cname\_record](#module\_service\_cname\_record) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
 
 ## Resources

--- a/services/xenorchestra/main.tf
+++ b/services/xenorchestra/main.tf
@@ -1,10 +1,10 @@
 module "fcos" {
-  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.4"
+  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.5"
   # source = "../../base/fcos/stack"
 
   fqdn      = var.fqdn
   desc      = "Xen Orchestra (Community Edition)"
-  xo_tags   = concat(var.xo_tags, ["xenorchestra"])
+  xo_tags   = concat(var.xo_tags, ["service=xenorchestra"])
   memory    = 3072
   cpu_cores = 2
   disk_size = 30

--- a/services/zammad/README.md
+++ b/services/zammad/README.md
@@ -15,7 +15,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.4 |
+| <a name="module_fcos"></a> [fcos](#module\_fcos) | git@github.com:nop-systems/tf-modules.git//base/fcos/stack | fcos/v0.6.5 |
 | <a name="module_service_cname_record"></a> [service\_cname\_record](#module\_service\_cname\_record) | git@github.com:nop-systems/tf-modules.git//base/dns-record | dns-record/v0.2.0 |
 
 ## Resources

--- a/services/zammad/main.tf
+++ b/services/zammad/main.tf
@@ -1,5 +1,5 @@
 module "fcos" {
-  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.4"
+  source = "git@github.com:nop-systems/tf-modules.git//base/fcos/stack?ref=fcos/v0.6.5"
 
   fqdn      = var.fqdn
   desc      = "zammad"


### PR DESCRIPTION
- **authentik: update to fcos/v0.6.5, authentik 2025.2.3**
- **bump pretix, xenorchestra, zammad to fcos/v0.6.5**
- **openproject: bump to fcos/v0.6.5, move images from template to template variable**
- **pretix: bump to 2025.3**
- **nextcloud: fix typo in caddy config**
- **nextcloud: bump to fcos/v0.6.5, nextcloud 31.0.2, valkey 8, caddy 2.9, collabora 24.04.13.2.1**
- **monitoring: bump fcos/v0.6.5, prometheus 3.2, grafana 11.6, loki 3.4, and all other images**
