### PR TITLE
fcos: fix dependency cycle in path unit

### DIFF
--- a/base/fcos/ignition/templates/ssh.bu.tftpl
+++ b/base/fcos/ignition/templates/ssh.bu.tftpl
@@ -44,7 +44,6 @@ systemd:
       contents: |
         [Unit]
         Description=Watch ssh host cert for changes
-        After=vault-agent.service
         [Path]
         PathChanged=/var/containers/secrets/ssh/ssh_host_ed25519_key-cert.pub
         [Install]


### PR DESCRIPTION
```
Apr 02 23:04:56 systemd[1]: basic.target: Found ordering cycle on paths.target/start
Apr 02 23:04:56 systemd[1]: basic.target: Found dependency on xenorchestra-reload-on-cert-renew.path/start
Apr 02 23:04:56 systemd[1]: basic.target: Found dependency on vault-agent.service/start
Apr 02 23:04:56 systemd[1]: basic.target: Found dependency on vault-agent-pod.service/start
Apr 02 23:04:56 systemd[1]: basic.target: Found dependency on network-online.target/start
Apr 02 23:04:56 systemd[1]: basic.target: Found dependency on nmstate.service/start
Apr 02 23:04:56 systemd[1]: basic.target: Found dependency on NetworkManager.service/start
Apr 02 23:04:56 systemd[1]: basic.target: Found dependency on basic.target/start
Apr 02 23:04:56 systemd[1]: basic.target: Job paths.target/start deleted to break ordering cycle starting with basic.target/start
Apr 02 23:05:02 systemd[1]: Starting vault-agent.service - Vault Agent...
```
