### PR TITLE
FCOS: fix PXE download urls

### DIFF
--- a/base/fcos/matchbox/README.md
+++ b/base/fcos/matchbox/README.md
@@ -35,7 +35,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_fcos_stream"></a> [fcos\_stream](#input\_fcos\_stream) | Fedora CoreOS stream | `string` | `"stable"` | no |
-| <a name="input_fcos_version"></a> [fcos\_version](#input\_fcos\_version) | Fedora CoreOS version (defaults to latest) | `string` | `null` | no |
 | <a name="input_fqdn"></a> [fqdn](#input\_fqdn) | FQDN of the new Virtual Machine | `string` | n/a | yes |
 | <a name="input_ignition"></a> [ignition](#input\_ignition) | compiled ignition config | `string` | n/a | yes |
 | <a name="input_mac_address"></a> [mac\_address](#input\_mac\_address) | MAC address of VM | `string` | n/a | yes |
@@ -63,8 +62,6 @@ module "" {
   
   /* Fedora CoreOS stream (optional) */
   # fcos_stream = stable
-  /* Fedora CoreOS version (defaults to latest) (optional) */
-  # fcos_version = <no value>
 }
 
 module "" {

--- a/base/fcos/matchbox/main.tf
+++ b/base/fcos/matchbox/main.tf
@@ -3,22 +3,25 @@ data "http" "fcos_releases" {
 }
 
 locals {
-  fcos_latest  = jsondecode(data.http.fcos_releases.response_body).architectures.x86_64.artifacts.metal.release
-  fcos_version = var.fcos_version != null ? var.fcos_version : local.fcos_latest
+  fcos_release_json = jsondecode(data.http.fcos_releases.response_body)
+  # fcos_latest       = local.fcos_release_json.architectures.x86_64.artifacts.metal.release
+  fcos_kernel    = local.fcos_release_json.architectures.x86_64.artifacts.metal.formats.pxe.kernel.location
+  fcos_initramfs = local.fcos_release_json.architectures.x86_64.artifacts.metal.formats.pxe.initramfs.location
+  fcos_rootfs    = local.fcos_release_json.architectures.x86_64.artifacts.metal.formats.pxe.roots.location
 }
 
 // Fedora CoreOS profile
 resource "matchbox_profile" "this" {
   name   = var.fqdn
-  kernel = "https://builds.coreos.fedoraproject.org/prod/streams/${var.fcos_stream}/builds/${local.fcos_version}/x86_64/fedora-coreos-${local.fcos_version}-live-kernel-x86_64"
+  kernel = local.fcos_kernel
 
   initrd = [
-    "--name main https://builds.coreos.fedoraproject.org/prod/streams/${var.fcos_stream}/builds/${local.fcos_version}/x86_64/fedora-coreos-${local.fcos_version}-live-initramfs.x86_64.img"
+    "--name main ${local.fcos_initramfs}"
   ]
 
   args = [
     "initrd=main",
-    "coreos.live.rootfs_url=https://builds.coreos.fedoraproject.org/prod/streams/${var.fcos_stream}/builds/${local.fcos_version}/x86_64/fedora-coreos-${local.fcos_version}-live-rootfs.x86_64.img",
+    "coreos.live.rootfs_url=${local.fcos_rootfs}",
     "coreos.inst.install_dev=/dev/xvda",
     "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}"
   ]

--- a/base/fcos/matchbox/variables.tf
+++ b/base/fcos/matchbox/variables.tf
@@ -9,12 +9,6 @@ variable "fcos_stream" {
   default     = "stable"
 }
 
-variable "fcos_version" {
-  type        = string
-  description = "Fedora CoreOS version (defaults to latest)"
-  default     = null
-}
-
 variable "mac_address" {
   type        = string
   description = "MAC address of VM"


### PR DESCRIPTION
The filename format has changed, which broke deployments.
Instead of constructing the urls ourselves just take the one from the
json.

Remove fcos_version var because there is no json for older versions and
this has no reasonable use case.
