### PR TITLE
fix: caddy 2.10 does panic due to catch all next to hostname

### DIFF
--- a/services/engelsystem/caddy.bu
+++ b/services/engelsystem/caddy.bu
@@ -87,7 +87,7 @@ storage:
             log
           }
 
-          https://${fqdn}, https://${service_fqdn}, https:// {
+          https://${fqdn}, https://${service_fqdn} {
             import common
 
 

--- a/services/monitoring/caddy.bu
+++ b/services/monitoring/caddy.bu
@@ -45,7 +45,7 @@ storage:
           }
 
           # Grafana
-          https://${fqdn}, https://grafana.${fqdn}, https://${grafana_fqdn}, https://${service_fqdn}, https:// {
+          https://${fqdn}, https://grafana.${fqdn}, https://${grafana_fqdn}, https://${service_fqdn} {
             import common
             reverse_proxy systemd-grafana:3000
           }

--- a/services/nextcloud/caddy.bu
+++ b/services/nextcloud/caddy.bu
@@ -99,7 +99,7 @@ storage:
             respond "Forbidden" 403
           }
 
-          https://${fqdn}, https://${nextcloud_service_fqdn}, https:// {
+          https://${fqdn}, https://${nextcloud_service_fqdn} {
             import common
 
             reverse_proxy /whiteboard/* systemd-whiteboard:3002

--- a/services/openproject/openproject.bu
+++ b/services/openproject/openproject.bu
@@ -237,7 +237,7 @@ storage:
             fallback_sni ${service_fqdn}
           }
 
-          https://${fqdn}, https://${service_fqdn}, https:// {
+          https://${fqdn}, https://${service_fqdn} {
             tls {
               issuer acme {
                 # disable http challenge because only https port is published

--- a/services/pretix/caddy.bu
+++ b/services/pretix/caddy.bu
@@ -87,7 +87,7 @@ storage:
             log
           }
 
-          https://${fqdn}, https://${service_fqdn}, https:// {
+          https://${fqdn}, https://${service_fqdn} {
             import common
 
 

--- a/services/zammad/zammad.bu
+++ b/services/zammad/zammad.bu
@@ -260,7 +260,7 @@ storage:
             }
           }
 
-          https://${fqdn}, https://${service_fqdn}, https:// {
+          https://${fqdn}, https://${service_fqdn} {
             tls {
               issuer acme {
                 # disable http challenge because only https port is published


### PR DESCRIPTION
The catch-all existed only to ease debugging so it can be removed.

> Error: adapting config using caddyfile: automation policy from site block is also default/catch-all policy because of key without hostname, and the two are in conflict: []certmagic.Issuer(nil) != []certmagic.Issuer{(*caddytls.ACMEIssuer)(0xc0007e0b48)}
